### PR TITLE
Fix the git clone command for the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ pip3 install openai
 2. Download the ZSH plugin.
 
 ```
-    $ git clone https://github.com/tom-doerr/zsh_codex.git ~/.oh-my-zsh/custom/plugins/ 
+    $ git clone https://github.com/tom-doerr/zsh_codex.git ~/.oh-my-zsh/custom/plugins/zsh_codex 
 ```
 
 3. Add the following to your `.zshrc` file.


### PR DESCRIPTION
The `git clone` command may throw errors like:

```console
$ git clone https://github.com/tom-doerr/zsh_codex.git ~/.oh-my-zsh/custom/plugins/
fatal: destination path '/home/$USER/.oh-my-zsh/custom/plugins' already exists and is not an empty directory.
```

Adding the full path helps to mitigate this problem.