### PR TITLE
Add Fig as an installation method to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To use this plugin you need to get access to OpenAI's [Codex API](https://openai
 
 
 ## How do I install it?
-
+### Manual Installation
 1. Install the OpenAI package.
 ```
 pip3 install openai
@@ -84,6 +84,13 @@ secret_key = ...
 
 5. Run `zsh`, start typing and complete it using `^X`!
 
+### Fig Installation
+
+[Fig](https://fig.io) adds apps, shortcuts, and autocomplete to your existing terminal.
+
+Install `zsh_codex` in just one click.
+
+<a href="https://fig.io/plugins/other/zsh_codex_tom-doerr" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
 
 ## Troubleshooting 
 

--- a/README.md
+++ b/README.md
@@ -86,10 +86,6 @@ secret_key = ...
 
 ### Fig Installation
 
-[Fig](https://fig.io) adds apps, shortcuts, and autocomplete to your existing terminal.
-
-Install `zsh_codex` in just one click.
-
 <a href="https://fig.io/plugins/other/zsh_codex_tom-doerr" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
 
 ## Troubleshooting 


### PR DESCRIPTION
We recently listed Zsh Codex in [Fig Plugin Store](https://fig.io/plugins), so we'd love to have Fig listed as a download method on your readme. We have over 100k users that will benefit from this. 

Thanks so much and please let me know if you have any questions!

