### PR TITLE
feat: replace openai with llmhub

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,15 +47,21 @@
 ## What is it?
 
 This is a ZSH plugin that enables you to use OpenAI's powerful Codex AI in the command line. OpenAI Codex is the AI that also powers GitHub Copilot.
-To use this plugin you need to get access to OpenAI's [Codex API](https://openai.com/blog/openai-codex/).
+To use this plugin you'll need to authenatice with [LLMHub](https://www.llmhub.com) - details are below.
 
 
 ## How do I install it?
 ### Manual Installation
-1. Install the OpenAI package.
+1. Install the LLMHub package.
 ```
-pip3 install openai
+pip3 install llmhub
 ```
+
+2. Authenticate against LLMHub.
+```
+llmhub auth
+```
+This will open a single-sign on page, and everything should be setup after that.
 
 2. Download the ZSH plugin.
 
@@ -76,14 +82,6 @@ Without oh-my-zsh:
     export ZSH_CUSTOM="your/custom/path"
     source "$ZSH_CUSTOM/plugins/zsh_codex/zsh_codex.plugin.zsh"
     bindkey '^X' create_completion
-```
-
-4. Create a file called `openaiapirc` in `~/.config` with your ORGANIZATION_ID and SECRET_KEY.
-
-```
-[openai]
-organization_id = ...
-secret_key = ...
 ```
 
 5. Run `zsh`, start typing and complete it using `^X`!

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ To use this plugin you'll need to authenatice with [LLMHub](https://www.llmhub.c
 pip3 install llmhub
 ```
 
-2. Authenticate against LLMHub.
+2. Authenticate against LLMHub **once**.
 ```
 llmhub auth
 ```

--- a/create_completion.py
+++ b/create_completion.py
@@ -1,58 +1,13 @@
 #!/usr/bin/env python3
 
-import openai
+from llmhub.client import Client as LLMHubClient
 import sys
 import os
 import configparser
 
 STREAM = False
 
-
-# Get config dir from environment or default to ~/.config
-CONFIG_DIR = os.getenv('XDG_CONFIG_HOME', os.path.expanduser('~/.config'))
-API_KEYS_LOCATION = os.path.join(CONFIG_DIR, 'openaiapirc')
-
-# Read the organization_id and secret_key from the ini file ~/.config/openaiapirc
-# The format is:
-# [openai]
-# organization_id=<your organization ID>
-# secret_key=<your secret key>
-
-# If you don't see your organization ID in the file you can get it from the
-# OpenAI web site: https://openai.com/organizations
-def create_template_ini_file():
-    """
-    If the ini file does not exist create it and add the organization_id and
-    secret_key
-    """
-    if not os.path.isfile(API_KEYS_LOCATION):
-        with open(API_KEYS_LOCATION, 'w') as f:
-            f.write('[openai]\n')
-            f.write('organization_id=\n')
-            f.write('secret_key=\n')
-
-        print('OpenAI API config file created at {}'.format(API_KEYS_LOCATION))
-        print('Please edit it and add your organization ID and secret key')
-        print('If you do not yet have an organization ID and secret key, you\n'
-               'need to register for OpenAI Codex: \n'
-                'https://openai.com/blog/openai-codex/')
-        sys.exit(1)
-
-
-def initialize_openai_api():
-    """
-    Initialize the OpenAI API
-    """
-    # Check if file at API_KEYS_LOCATION exists
-    create_template_ini_file()
-    config = configparser.ConfigParser()
-    config.read(API_KEYS_LOCATION)
-
-    openai.organization_id = config['openai']['organization_id'].strip('"').strip("'")
-    openai.api_key = config['openai']['secret_key'].strip('"').strip("'")
-
-
-initialize_openai_api()
+LLM = LLMHubClient("https://www.llmhub.com/2/functions/34/share")
 
 cursor_position_char = int(sys.argv[1])
 
@@ -61,26 +16,25 @@ buffer = sys.stdin.read()
 prompt_prefix = '#!/bin/zsh\n\n' + buffer[:cursor_position_char]
 prompt_suffix = buffer[cursor_position_char:]
 
-response = openai.Completion.create(engine='code-davinci-002', prompt=prompt_prefix, suffix=prompt_suffix, temperature=0.5, max_tokens=50, stream=STREAM)
+response = LLM.run({"prefix": prompt_prefix,
+                    "suffix": prompt_suffix,})
+                    #"stream": STREAM,})
 
-if STREAM:
-    while True:
-        next_response = next(response)
-        print("next_response:", next_response)
-        print("        next_response['choices'][0]['finish_reason']:",         next_response['choices'][0]['finish_reason'])
-        completion = next_response['choices'][0]['text']
-        print("completion:", completion)
+# if STREAM:
+#     while True:
+#         next_response = next(response)
+#         print("next_response:", next_response)
+#         print("        next_response['choices'][0]['finish_reason']:",         next_response['choices'][0]['finish_reason'])
+#         completion = next_response['choices'][0]['text']
+#         print("completion:", completion)
+# else:
+completion_all = response["output"]
+completion_list = completion_all.split('\n')
+if completion_all[:2] == '\n\n':
+    print(completion_all)
+elif completion_list[0]:
+    print(completion_list[0])
+elif len(completion_list) == 1:
+    print('')
 else:
-    completion_all = response['choices'][0]['text']
-    completion_list = completion_all.split('\n')
-    if completion_all[:2] == '\n\n':
-        print(completion_all)
-    elif completion_list[0]:
-        print(completion_list[0])
-    elif len(completion_list) == 1:
-        print('')
-    else:
-        print('\n' + completion_list[1])
-
-
-
+    print('\n' + completion_list[1])

--- a/create_completion.py
+++ b/create_completion.py
@@ -5,8 +5,6 @@ import sys
 import os
 import configparser
 
-STREAM = False
-
 LLM = LLMHubClient("https://www.llmhub.com/2/functions/34/share")
 
 cursor_position_char = int(sys.argv[1])
@@ -18,16 +16,7 @@ prompt_suffix = buffer[cursor_position_char:]
 
 response = LLM.run({"prefix": prompt_prefix,
                     "suffix": prompt_suffix,})
-                    #"stream": STREAM,})
 
-# if STREAM:
-#     while True:
-#         next_response = next(response)
-#         print("next_response:", next_response)
-#         print("        next_response['choices'][0]['finish_reason']:",         next_response['choices'][0]['finish_reason'])
-#         completion = next_response['choices'][0]['text']
-#         print("completion:", completion)
-# else:
 completion_all = response["output"]
 completion_list = completion_all.split('\n')
 if completion_all[:2] == '\n\n':


### PR DESCRIPTION
# Summary

This PR integrates [LLMHub](https://www.llmhub.com). This integration allows users to get started right away (1-click!), and automatically integrates all relevant LLM providers without requiring users to set up API keys with each. Additionally we provide various tools to make it easier to improve its accuracy/latency/costs (via tools for finetuning & prompt engineering). 

A user would only need to do the following to get started:
```bash
pip3 install llmhub
# llmhub was globally installed as part of previous command.
llmhub auth
```
`llmhub auth` points users to a webpage where they need to sign in via GitHub. That's it!

# Features

### :massage: Allow users to use your app in 1-click.

### :computer: Deploy in 1-click.

### :haircut: Integrate ANY LLM in 3-lines with a standardised API.

### :wrench: Monitor and improve your prompts.

### :earth_americas: Discover new prompts easily, and showcase your work.

### :muscle: Contribute to popular prompts, and improve your skills.

### :dollar: Free credits while we're in beta

# Some things to note

- The current prompts are deployed to be an **exact replica** of existing code (models & parameters like temperature/frequency_penalty). Easy to edit.
- We'd love to keep this LLM work public/open-source. Is that OK? 

# About Us

We're @vatsalaggarwal and @sidroopdaska. @sidroopdaska was the second engineering hire at the largest autonomous driving company in Europe, and I was an ML Scientist at Amazon for 4 years and researched deep generative models!