### PR TITLE
Remove prompt prefix from completion result

### DIFF
--- a/create_completion.py
+++ b/create_completion.py
@@ -77,4 +77,5 @@ response = openai.ChatCompletion.create(model=model, messages=[
 ])
 completed_command = response['choices'][0]['message']['content']
 
-sys.stdout.write(f"\n{completed_command}")
+sys.stdout.write(f"\n{completed_command.replace(prompt_prefix, '', 1)}")
+


### PR DESCRIPTION
When I write "# commit dotfiles" and press C-x, my terminal looks like this:
```
➜  ~ # commit dotfiles
#!/bin/zsh

# commit dotfiles
git add . && git commit -m "Update dotfiles"
```

If you merge this PR, it will look like this:
```
➜  ~ # commit dotfiles
git add . && git commit -m "Update dotfiles"
```

