### PR TITLE
Support oh-my-zsh variants like antidote

### DIFF
--- a/zsh_codex.plugin.zsh
+++ b/zsh_codex.plugin.zsh
@@ -4,11 +4,13 @@
 # and uses a Python script to complete the text.
 api="openai"
 
+_ZSH_CODEX_REPO=$(dirname $0)
+
 create_completion() {
     # Get the text typed until now.
     local text=$BUFFER
     local ZSH_CODEX_PYTHON="${ZSH_CODEX_PYTHON:-python3}"
-    local completion=$(echo -n "$text" | $ZSH_CODEX_PYTHON $ZSH_CUSTOM/plugins/zsh_codex/create_completion.py --api "$api" $CURSOR)
+    local completion=$(echo -n "$text" | $ZSH_CODEX_PYTHON $_ZSH_CODEX_REPO/create_completion.py --api "$api" $CURSOR)
     local text_before_cursor=${BUFFER:0:$CURSOR}
     local text_after_cursor=${BUFFER:$CURSOR}
     


### PR DESCRIPTION
They clone plugins in a different format which means you can't resolve the repo dir from ZSH_CUSTOM.

I'm 90% sure this should still work on vanilla oh-my-zsh but to be sure someone may want to test.