### PR TITLE
Support for other services API

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,20 +87,37 @@ Without oh-my-zsh:
    Example:
 
 ```ini
+; Primary service configuration
+; Set 'service' to match one of the defined sections below.
 [service]
-service = ollama_local ; the active service
+service = groq_service
 
-; api_type: Mandatory for every service. Choose between "openai" and "gemeni"
-
-[ollama_local] ; this can be any name
-api_type = openai ; check services/services.py for available parameters for this api_type
+; Example configuration for a self-hosted Ollama service.
+[my_ollama]
+api_type = openai
 api_key = dummy_key
 model = llama3.1
 base_url = http://localhost:11434/v1
 
-[openai]
+; OpenAI service configuration
+; Provide the 'api_key' and specify a 'model' if needed.
+[openai_service]
 api_type = openai
-api_key = your_openai_api_key
+api_key = <openai_apikey>
+
+; Groq service configuration
+; Provide the 'api_key'.
+[groq_service]
+api_type = groq
+api_key = <groq_apikey>
+model = gemma2-9b-it
+
+; Mistral service configuration
+; Provide the 'api_key'.
+[mistral_service]
+api_type = mistral
+api_key = <mistral_apikey>
+model = mistral-small-latest
 ```
 
 In this configuration file, you can define multiple services with their own configurations. The required and optional parameters of the `api_type` are specified in `services/sevices.py`. Choose which service to use in the `[service]` section.

--- a/services/services.py
+++ b/services/services.py
@@ -92,9 +92,47 @@ class GoogleGenAIClient(BaseClient):
         response = chat.send_message(prompt)
         return response.text
 
+class GroqClient(BaseClient):
+    """
+    config keys:
+        - api_type="groq"
+        - api_key (required)
+        - model (optional): defaults to "llama-3.2-11b-text-preview"
+        - temperature (optional): defaults to 1.0.
+    """
+    
+    api_type = "groq"
+    default_model = os.getenv("GROQ_DEFAULT_MODEL", "llama-3.2-11b-text-preview")
+    
+    def __init__(self, config: dict):
+        try:
+            from groq import Groq
+        except ImportError:
+            print(
+                "Groq library is not installed. Please install it using 'pip install groq'"
+            )
+            sys.exit(1)
+
+        self.config = config
+        self.config["model"] = self.config.get("model", self.default_model)
+        self.client = Groq(
+            api_key=self.config["api_key"],
+        )
+    
+    def get_completion(self, full_command: str) -> str:
+        response = self.client.chat.completions.create(
+            model=self.config["model"],
+            messages=[
+                {"role": "system", "content": self.system_prompt},
+                {"role": "user", "content": full_command},
+            ],
+            temperature=float(self.config.get("temperature", 1.0)),
+        )
+        return response.choices[0].message.content
+    
 
 class ClientFactory:
-    api_types = [OpenAIClient.api_type, GoogleGenAIClient.api_type]
+    api_types = [OpenAIClient.api_type, GoogleGenAIClient.api_type, GroqClient.api_type]
 
     @classmethod
     def create(cls):
@@ -112,6 +150,8 @@ class ClientFactory:
                 return OpenAIClient(config)
             case GoogleGenAIClient.api_type:
                 return GoogleGenAIClient(config)
+            case GroqClient.api_type:
+                return GroqClient(config)
             case _:
                 raise KeyError(
                     f"Specified API type {api_type} is not one of the supported services {cls.api_types}"


### PR DESCRIPTION
I added the support for both [Groq](https://groq.com/) and [Mistral](https://mistral.ai/) APIs.
Both services offer the option to obtain a free API key.

Since the README update PR #53 is still pending, I’m including a sample configuration file below to demonstrate how to configure the new services.
```
[service]
service = groq_service

; api_type: choose between "openai", "gemini", "groq", "mistral"
[my_ollama]
api_type = openai
api_key = dummy_key
model = llama3.1
base_url = http://localhost:11434/v1

[openai_service]
api_type = openai
api_key = <openai_apikey>

[groq_service]
api_type = groq
api_key = <groq_apikey>
model = gemma2-9b-it

[mistral_service]
api_type = mistral
api_key = <mistral_apikey>
model = mistral-small-latest
```

- Replace `<openai_apikey>`, `<groq_apikey>`, and `<mistral_apikey>` with your respective API keys.
- The `service` field should match the desired service you want to use, such as `groq_service` or `mistral_service`.