### PR TITLE
Add support for Amazon Bedrock (defaulting to Claude)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This is a ZSH plugin that enables you to use AI powered code completion in the c
 
 ### Manual Installation
 
-1. Install the OpenAI package or the Google package.
+1. Install the OpenAI package, the Google package, or boto3.
 
 ```bash
 pip3 install openai
@@ -57,6 +57,12 @@ or
 
 ```bash
 pip3 install google-generativeai
+```
+
+or
+
+```bash
+pip3 install boto3
 ```
 
 2. Download the ZSH plugin.


### PR DESCRIPTION
Hi, 

I created this commit to use Amazon Bedrock back-end.  I've been using this for about a week, and it works great.  

I was able to test this with our org's Control Tower setup (with Key, Secret, and Session Token) in us-east-1 and the latest Claude. 

I can't guarantee it works with models other than Claude since each model could potentially have its own message API shape.  

Let me know if there's anything I should do differently here or if we're good to merge.