### PR TITLE
Add a new ZSH_CODEX_PREEXECUTE_COMMENT shell variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,21 @@ git clone https://github.com/tom-doerr/zsh_codex.git ~/.oh-my-zsh/custom/plugins
     <a href="https://www.buymeacoffee.com/TomDoerr" target="_blank"><img src="https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png" alt="Buy Me A Coffee" style="height: 41px !important;width: 174px !important;box-shadow: 0px 3px 2px 0px rgba(190, 190, 190, 0.5) !important;-webkit-box-shadow: 0px 3px 2px 0px rgba(190, 190, 190, 0.5) !important;" ></a>
 </p>
 
+## Passing in context
+
+Since the current filesystem is not passed into the ai you will need to either
+A. Pass in all context in your descriptive command
+B. Use a command to collect the context
+
+In order for option B to work you will need to first add `export ZSH_CODEX_PREEXECUTE_COMMENT="true"` to your .zshrc file to enable the feature. 
+
+> [!WARNING]
+> This will run your prompt using zsh each time before using it, which could potentially modify your system when you hit ^X.
+
+Once you've done that and restarted your shell you can do things like this:
+
+`# git add all files. Also commit the current changeset with a descriptive message based on $(git diff). Then git push`
+
 ## More usage examples
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -178,10 +178,10 @@ git clone https://github.com/tom-doerr/zsh_codex.git ~/.oh-my-zsh/custom/plugins
 ## Passing in context
 
 Since the current filesystem is not passed into the ai you will need to either
-A. Pass in all context in your descriptive command
-B. Use a command to collect the context
+1. Pass in all context in your descriptive command
+2. Use a command to collect the context
 
-In order for option B to work you will need to first add `export ZSH_CODEX_PREEXECUTE_COMMENT="true"` to your .zshrc file to enable the feature. 
+In order for option 2 to work you will need to first add `export ZSH_CODEX_PREEXECUTE_COMMENT="true"` to your .zshrc file to enable the feature. 
 
 > [!WARNING]
 > This will run your prompt using zsh each time before using it, which could potentially modify your system when you hit ^X.

--- a/zsh_codex.plugin.zsh
+++ b/zsh_codex.plugin.zsh
@@ -10,7 +10,7 @@ create_completion() {
     # Get the text typed until now.
     local text=$BUFFER
     if [[ "$ZSH_CODEX_PREEXECUTE_COMMENT" == "true" ]]; then
-        text="$(echo -n "echo \"$text\"" | bash)"
+        text="$(echo -n "echo \"$text\"" | zsh)"
     fi
     local ZSH_CODEX_PYTHON="${ZSH_CODEX_PYTHON:-python3}"
     local completion=$(echo -n "$text" | $ZSH_CODEX_PYTHON $_ZSH_CODEX_REPO/create_completion.py $CURSOR)

--- a/zsh_codex.plugin.zsh
+++ b/zsh_codex.plugin.zsh
@@ -9,6 +9,9 @@ _ZSH_CODEX_REPO=$(dirname $0)
 create_completion() {
     # Get the text typed until now.
     local text=$BUFFER
+    if [[ "$ZSH_CODEX_PREEXECUTE_COMMENT" == "true" ]]; then
+        text="$(echo -n "echo \"$text\"" | bash)"
+    fi
     local ZSH_CODEX_PYTHON="${ZSH_CODEX_PYTHON:-python3}"
     local completion=$(echo -n "$text" | $ZSH_CODEX_PYTHON $_ZSH_CODEX_REPO/create_completion.py $CURSOR)
     local text_before_cursor=${BUFFER:0:$CURSOR}


### PR DESCRIPTION
The intent is to enable executing the prompt using zsh before passing it in. That way you can have pre-built prompts which can gather environmental context for advanced usages